### PR TITLE
Fix: ensure launch.classpath in nextflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,12 @@ To run and test the plugin in for development purpose, configure a local Nextflo
     ./gradlew compileGroovy
     ```
 
-4. Run Nextflow with the plugin, using `./launch.sh` as a drop-in replacement for the `nextflow` command, and adding the option `-plugins nf-hello` to load the plugin:
+4. Generate nextflow `.launch.classpath`:
+    ```bash
+    cd ../nextflow && ./gradlew exportClasspath && cd ../nf-hello
+    ```
+
+5. Run Nextflow with the plugin, using `./launch.sh` as a drop-in replacement for the `nextflow` command, and adding the option `-plugins nf-hello` to load the plugin:
     ```bash
     ./launch.sh run nextflow-io/hello -plugins nf-hello
     ```


### PR DESCRIPTION
Hello 🙂 

By default, this current README procedure will crash with an:

```
+ [[ ! -f /subdir/nextflow/.launch.classpath ]]
+ echo 'Missing '\''.launch.classpath'\'' file -- create it by running: ./gradlew exportClasspath'
Missing '.launch.classpath' file -- create it by running: ./gradlew exportClasspath
+ exit 1
```

This comes from launch.sh from main nextflow git repository. User needs to cd into main nextflow directory just cloned and generate missing files.

Tested on Ubuntu 20.04 with OpenJDK 16.