### PR TITLE
Address deprecation warnings for tests and add local install gradle action

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-
 config ?= compileClasspath
 
 ifdef module 
@@ -53,7 +52,6 @@ assemble:
 
 #
 # generate build zips under build/plugins
-# you can install the plugin copying manually these files to $HOME/.nextflow/plugins
 #
 buildPlugins:
 	./gradlew copyPluginZip
@@ -70,3 +68,9 @@ upload-plugins:
 
 publish-index:
 	./gradlew plugins:publishIndex
+
+#
+# Install plugin to ~/.nextflow/plugins using Gradle
+#
+install-plugin:
+	./gradlew installPlugin

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ publish-index:
 #
 install-plugin:
 ifdef plugin
-	./gradlew installSpecificPlugin -Pplugin=${plugin}
+	./gradlew :plugins:${plugin}:installPlugin
 else
-	./gradlew installPlugins
+	./gradlew installPlugin
 endif

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,11 @@ publish-index:
 
 #
 # Install plugin to ~/.nextflow/plugins using Gradle
+# Usage: make install-plugin [plugin=nf-hello]
 #
 install-plugin:
-	./gradlew installPlugin
+ifdef plugin
+	./gradlew installSpecificPlugin -Pplugin=${plugin}
+else
+	./gradlew installPlugins
+endif

--- a/README.md
+++ b/README.md
@@ -90,7 +90,30 @@ To build and test the plugin during development, configure a local Nextflow buil
 The plugin can be tested without using a local Nextflow build using the following steps:
 
 1. Build the plugin: `make buildPlugins`
-2. Copy `build/plugins/<your-plugin>` to `$HOME/.nextflow/plugins`
+2. Install the plugin using one of these methods:
+
+   ```bash
+   # Install a specific plugin (if you have added new plugins to the plugins/ directory)
+   make install-plugin plugin=nf-hello
+
+   # Install all available plugins
+   make install-plugin
+   ```
+
+   The plugins will be installed to one of these locations, in order of precedence:
+   - Directory specified by `NXF_PLUGINS_DIR` environment variable
+   - `$NXF_HOME/plugins` if `NXF_HOME` is set
+   - `$HOME/.nextflow/plugins` (default location)
+
+   Alternatively, you can use Gradle commands directly:
+   ```bash
+   # Install a specific plugin
+   ./gradlew installSpecificPlugin -Pplugin=nf-hello
+
+   # Install all plugins
+   ./gradlew installPlugins
+   ```
+
 3. Create a pipeline that uses your plugin and run it: `nextflow run ./my-pipeline-script.nf`
 
 ## Package, upload, and publish

--- a/README.md
+++ b/README.md
@@ -108,10 +108,10 @@ The plugin can be tested without using a local Nextflow build using the followin
    Alternatively, you can use Gradle commands directly:
    ```bash
    # Install a specific plugin
-   ./gradlew installSpecificPlugin -Pplugin=nf-hello
+   ./gradlew :plugins:nf-hello:installPlugin
 
    # Install all plugins
-   ./gradlew installPlugins
+   ./gradlew installPlugin
    ```
 
 3. Create a pipeline that uses your plugin and run it: `nextflow run ./my-pipeline-script.nf`

--- a/plugins/build.gradle
+++ b/plugins/build.gradle
@@ -153,6 +153,44 @@ subprojects {
     }
     
     task upload(dependsOn: [uploadPlugin] ) { }
+
+    /*
+     * Task to install plugin to the Nextflow plugins directory for local testing and development.
+     * For production deployment, see "Package, upload, and publish" section in README.md.
+     */
+    task installPlugin(type: Copy, dependsOn: copyPluginZip) {
+        description = "Installs ${project.name} plugin to the Nextflow plugins directory"
+        group = 'Plugin Installation'
+
+        def pluginsDir = System.getenv('NXF_PLUGINS_DIR') ?:
+                        System.getenv('NXF_HOME') ? "${System.getenv('NXF_HOME')}/plugins" :
+                        "${System.getProperty('user.home')}/.nextflow/plugins"
+        
+        // Use the subproject's name and version
+        def pluginZip = file("$rootProject.buildDir/plugins/${project.name}-${project.version}.zip")
+        def pluginDir = file("$pluginsDir/${project.name}-${project.version}")
+
+        doFirst {
+            println "Installing plugin ${project.name} version ${project.version} to: $pluginDir"
+            pluginDir.mkdirs()
+        }
+
+        from zipTree(pluginZip)
+        into pluginDir
+
+        doLast {
+            println "Plugin ${project.name} installed successfully!"
+            println "Installation location: $pluginDir"
+            println "Installation location determined by:"
+            if (System.getenv('NXF_PLUGINS_DIR')) {
+                println " - NXF_PLUGINS_DIR environment variable"
+            } else if (System.getenv('NXF_HOME')) {
+                println " - NXF_HOME environment variable"
+            } else {
+                println " - Default location (~/.nextflow/plugins)"
+            }
+        }
+    }
 }
 
 /*
@@ -175,4 +213,35 @@ task publishIndex( type: io.nextflow.gradle.tasks.GithubRepositoryPublisher ) {
     githubUser = github_username
     githubEmail = github_commit_email
     githubToken = github_access_token
+}
+
+/*
+ * Task to install all plugins to the Nextflow plugins directory
+ */
+task installPlugins() {
+    description = 'Installs all plugins to the Nextflow plugins directory'
+    group = 'Plugin Installation'
+    
+    dependsOn subprojects.installPlugin
+}
+
+/*
+ * Task to install a specific plugin by name
+ * Usage: ./gradlew installPlugin -Pplugin=nf-hello
+ */
+task installSpecificPlugin {
+    description = 'Installs a specific plugin (specify with -Pplugin=plugin-name)'
+    group = 'Plugin Installation'
+    
+    doFirst {
+        if (!project.hasProperty('plugin')) {
+            throw new GradleException("Please specify a plugin name using -Pplugin=plugin-name")
+        }
+        def pluginName = project.property('plugin')
+        def pluginProject = project.findProject(":plugins:${pluginName}")
+        if (!pluginProject) {
+            throw new GradleException("Plugin '${pluginName}' not found")
+        }
+        dependsOn pluginProject.installPlugin
+    }
 }

--- a/plugins/build.gradle
+++ b/plugins/build.gradle
@@ -215,33 +215,3 @@ task publishIndex( type: io.nextflow.gradle.tasks.GithubRepositoryPublisher ) {
     githubToken = github_access_token
 }
 
-/*
- * Task to install all plugins to the Nextflow plugins directory
- */
-task installPlugins() {
-    description = 'Installs all plugins to the Nextflow plugins directory'
-    group = 'Plugin Installation'
-    
-    dependsOn subprojects.installPlugin
-}
-
-/*
- * Task to install a specific plugin by name
- * Usage: ./gradlew installPlugin -Pplugin=nf-hello
- */
-task installSpecificPlugin {
-    description = 'Installs a specific plugin (specify with -Pplugin=plugin-name)'
-    group = 'Plugin Installation'
-    
-    doFirst {
-        if (!project.hasProperty('plugin')) {
-            throw new GradleException("Please specify a plugin name using -Pplugin=plugin-name")
-        }
-        def pluginName = project.property('plugin')
-        def pluginProject = project.findProject(":plugins:${pluginName}")
-        if (!pluginProject) {
-            throw new GradleException("Plugin '${pluginName}' not found")
-        }
-        dependsOn pluginProject.installPlugin
-    }
-}

--- a/plugins/nf-hello/build.gradle
+++ b/plugins/nf-hello/build.gradle
@@ -88,33 +88,3 @@ test {
     useJUnitPlatform()
 }
 
-// Task to install the plugin to the Nextflow plugins directory
-task installPlugin(type: Copy, dependsOn: copyPluginZip) {
-    def pluginsDir = System.getenv('NXF_PLUGINS_DIR') ?:
-                     System.getenv('NXF_HOME') ? "${System.getenv('NXF_HOME')}/plugins" :
-                     "${System.getProperty('user.home')}/.nextflow/plugins"
-    
-    def pluginZip = file("$rootProject.buildDir/plugins/${project.name}-${project.version}.zip")
-    def pluginDir = file("$pluginsDir/${project.name}-${project.version}")
-
-    doFirst {
-        println "Installing plugin to: $pluginDir"
-        pluginDir.mkdirs()
-    }
-
-    from zipTree(pluginZip)
-    into pluginDir
-
-    doLast {
-        println "Plugin installed successfully!"
-        println "Installation location determined by:"
-        if (System.getenv('NXF_PLUGINS_DIR')) {
-            println " - NXF_PLUGINS_DIR environment variable"
-        } else if (System.getenv('NXF_HOME')) {
-            println " - NXF_HOME environment variable"
-        } else {
-            println " - Default location (~/.nextflow/plugins)"
-        }
-    }
-}
-

--- a/plugins/nf-hello/build.gradle
+++ b/plugins/nf-hello/build.gradle
@@ -78,10 +78,43 @@ dependencies {
     modules {
         module("commons-logging:commons-logging") { replacedBy("org.slf4j:jcl-over-slf4j") }
     }
+
+    // Add this line to explicitly declare the test framework launcher
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 // use JUnit 5 platform
 test {
     useJUnitPlatform()
+}
+
+// Task to install the plugin to the Nextflow plugins directory
+task installPlugin(type: Copy, dependsOn: copyPluginZip) {
+    def pluginsDir = System.getenv('NXF_PLUGINS_DIR') ?:
+                     System.getenv('NXF_HOME') ? "${System.getenv('NXF_HOME')}/plugins" :
+                     "${System.getProperty('user.home')}/.nextflow/plugins"
+    
+    def pluginZip = file("$rootProject.buildDir/plugins/${project.name}-${project.version}.zip")
+    def pluginDir = file("$pluginsDir/${project.name}-${project.version}")
+
+    doFirst {
+        println "Installing plugin to: $pluginDir"
+        pluginDir.mkdirs()
+    }
+
+    from zipTree(pluginZip)
+    into pluginDir
+
+    doLast {
+        println "Plugin installed successfully!"
+        println "Installation location determined by:"
+        if (System.getenv('NXF_PLUGINS_DIR')) {
+            println " - NXF_PLUGINS_DIR environment variable"
+        } else if (System.getenv('NXF_HOME')) {
+            println " - NXF_HOME environment variable"
+        } else {
+            println " - Default location (~/.nextflow/plugins)"
+        }
+    }
 }
 


### PR DESCRIPTION
This adds a new make command and corresponding gradle task to install the plugin in the user's local plugins directory. This is to make it a little bit easier to get started with plugin development. 

```
make install-plugin
```